### PR TITLE
Fixed leJOS Project Type not visible in New Project wizard

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>org.lejos.intellij.plugin</id>
   <name>LeJOS Support for Lego EV3 Mindstorms</name>
-  <version>1.3</version>
+  <version>1.5</version>
   <vendor email="miguelcordovadev@gmail.com" url="https://github.com/miguelcordovam/leJOS_plugin">Miguel Cordovam</vendor>
 
   <description><![CDATA[
@@ -18,6 +18,9 @@
     ]]></description>
 
   <change-notes><![CDATA[
+      1.5 <br>
+      - Fixed Project Type missing in intelliJ 2022.1+ <br>
+
       1.4 <br>
       - Added Kotlin support. <br>
 

--- a/src/org/lejos/wizard/LejosModuleBuilder.java
+++ b/src/org/lejos/wizard/LejosModuleBuilder.java
@@ -60,4 +60,9 @@ public class LejosModuleBuilder extends JavaModuleBuilder {
     private void addLibrary(String library) {
         super.addModuleLibrary(library, "");
     }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
 }


### PR DESCRIPTION
Hey there,

I fixed this issue i discoverd a while ago: https://github.com/miguelcordovam/leJOS_plugin/issues/17
IntelliJ 2022.1 introduced an [Enhanced New Project wizard](https://www.jetbrains.com/idea/whatsnew/2022-1/#:~:text=Enhanced%20New%20Project%20wizard) which seems to [require the isAvailable() method in the ModuleBuilder class to return true](https://plugins.jetbrains.com/docs/intellij/project-wizard.html#implementing-module-builder:~:text=Starting%20with%20the%202022.1%20release%2C%20IntelliJ%2Dbased%20IDEs%20use%20the%20refreshed%20project%20wizard%20and%20some%20module%20builder%20base%20classes%20return%20false%20from%20isAvailable()%20when%20the%20new%20wizard%20is%20enabled.) to make the project type show up in the new project wizard. 

Best regards,
Till